### PR TITLE
Suggestions, mainly to add clarity to open works

### DIFF
--- a/source/open-definition-dev.markdown
+++ b/source/open-definition-dev.markdown
@@ -76,19 +76,19 @@ specific field of endeavor.
 ##### 1.1.9 No Charge
 
 The **license** *must* not impose any fee arrangements, compensation or monetary 
-remuneration as part of it's conditions. The only charge that may be made is for 
-any one-off reproduction cost, in the common case of downloading over the internet 
-the this cost would normally be zero.
+remuneration as part of its conditions. The only charge that may be made is for 
+any one-off reproduction cost (in the common case of downloading over the internet 
+the this cost would normally be zero).
 
 #### 1.2 Acceptable Conditions
 The **license** *may* condition the permissions granted in Section 1.1 on 
 compliance with the following conditions. Other conditions are not generally 
 permitted if they meaningfully limit or otherwise impact the permissions 
-required in Section 1.1.
+required in Section 1.1. The conditions *must* not seek to derogate from rights such as fair use and fair dealing, or from uses for which no licence is required at law.
 
 ##### 1.2.1 Attribution
 
-The **license** *may* require that contributors and creators of a licensed 
+The **license** *may* require that contributors, rights holders, sponsors and creators of a licensed 
 work be attributed in distributed versions of the work. If this condition 
 is imposed it *must* not be onerous. 
 
@@ -101,7 +101,7 @@ otherwise indicate what changes have been made.
 ##### 1.2.3 Share-alike
 
 The **license** *may* require that copies or adaptations of a licensed work be
-released under the same or similar license as the original.
+released under a licence the same as or similar to the original.
 
 
 ### 2. Open Works
@@ -123,15 +123,15 @@ The **work** shall be available as a whole and at no more than a reasonable
 reproduction cost, preferably downloadable via the Internet without charge.
 Any additional information necessary for license compliance (such as names of 
 contributors required for compliance with attribution requirements) *must* also 
-accompany the work.
+accompany the work.  "**Work**" includes non-transient derivatives of the **work** (for example, metadata).
 
 ##### 2.1.3 Open Format
 
 The **work** *must* be provided in a convenient and modifiable form such
 that there are no unnecessary technological obstacles to the performance of the
-licensed rights. Specifically, data should be machine-readable, available in
+licensed rights. Specifically, data should be machine-readable, available and, where hosted on an accessible network, downloadable in
 bulk and provided in an open data format (i.e., one whose specification is publicly
 and freely available and which places no restrictions monetary or otherwise upon
 its use) or, at the very least, can be processed with at least one free/open source
-software tool.
+software tool. 
 


### PR DESCRIPTION
1.2 Acceptable conditions
This issue came up during the drafting process for the CERN OHL. We were careful that the licence didn't seek to grant rights (and hence try to impose conditions) on IPRs that didn't exist. For example, where, as in the UK, in many cases it's not a breach of intellectual property rights, and therefore does not necessitate a licence, to make a 3d item from a 2d design, it's not acceptable simply to say "this licence grants you the right to make a 3d item from a 2d design" because this presupposes that a licence is necessary. Instead, it's much better to say "this licence grants you the rights, where necessary, to make a 3d item from a 2d design". This is important for a number of reasons - A. It does not set expectations that the particular IPR exists. I have a particular worry that a variant of the 'where value then right' fallacy will be applied, and that a future court will apply the reasoning that this IPR must exist, otherwise the licensor would not have applied a licence to it. It also seeks to establish community norms. B. This is a subtle, but I believe important, point, so bear with me! A licence may say 'You may do whatever you like with this work, provided that if you distribute any part of it, the whole work containing that part must be distributed under the same licence'. This looks like a standard sharealike licence, but it may be the case that the 'any part' is so small, or is otherwise not covered by copyright (through fair use/fair dealing for example) that the distribution in this form would not require a licence. Clearly, therefore, the distribution of the subsequent work is fine and does not infringe copyright. However, in a non-compliant licence, the distributor may lose her right to the ORIGINAL work by distributing contrary to this licence. This might seem like a highly technical issue, but in fact is important in the interpretation of GPL (v2 in particular), and with the current state of Oracle v Google, this really needs considering and analysing carefully. I admit A is more of a drafting issue for individual contracts, but I believe B is important for the definition. 

1.2.1 I have conflicting views about this clause. On the one hand, it should not only respect the attribution of contributors and creators, but also of rights holders (this is more for legal reasons - if the creators assign their rights to the Free Software Foundation, for example, the FSF will find it easier to enforce its rights if it is acknowledged as the rightsholder in the attriubtion) and sponsors (Canonical, in the case of Ubuntu, for example). On the other hand, this clause can, as is recognised, get very onerous, and I am glad that wording is in there, although the problem is that the onerousness of the clause is not so much determined by what is in the licence, but by the work to which it is attached, and so sits uneasily in the definition. If you look at the attribution clause in Apache, for example, that's fine for software, but would be horribly onerous if you applied it to an open database. Same licence - great for software, not so great for databases. 

1.2.3 Amended for clarity. Great clause, BTW - deals with both 'or later' and licences like EUPL which permit relicensing. 

2.1.1 General, for discussion (I haven't amended this as I'm not sure that it should go here, or in the licence part, but it's important that the rightsholder does not derogate from his grant by licensing with one licence (e.g. copyright), and then refusing to grant a patent licence, or granting it on discriminatory terms. On the other hand the rightsholder should NOT be required to grant a licence to trademarks, provided that it's reasonably simple to use the work without infringing the trademark, or to remove references to it entirely in order to allow the full spectrum of use.

2.1.2. This may be sneaking a form or copyleft (which is supposed to be optional) in by the back door, I admit, but I feel strongly that where a database, in particular, is provided, and the provider has generated metadata, that the metadata should also be available. 

2.1.3 I wanted to clarify that not only must the data be available in bulk, but the unnecessary technological obstacles must also apply to the downloading (where appropriate). For example, the system is designed to throttle downloads of more than so many records to a lower speed.
