### PR TITLE
adjustment to 2.2.3

### DIFF
--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -125,7 +125,7 @@ otherwise indicate what changes have been made.
 #### 2.2.3 Share-alike
 
 The **license** *may* require distributions of the work to remain
-under the same license the same or a similar license.
+under the same license or a similar license.
 
 #### 2.2.4 Notice
 

--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -125,7 +125,7 @@ otherwise indicate what changes have been made.
 #### 2.2.3 Share-alike
 
 The **license** *may* require distributions of the work to remain
-under license the same as or similar to the original.
+under the same license the same or a similar license.
 
 #### 2.2.4 Notice
 


### PR DESCRIPTION
"the original" isn't clear as it should be in this reading, anyway, my previous commit had error removing the "a" in 2.2.3. The issue with "original" refers to confusion about reference, distributions vs work vs license. I don't like how the solution is so wordy, but I think it's all around improvement, worth going with if nobody has any concerns.