### PR TITLE
specified "machine-readable" to be data-specific

### DIFF
--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -41,10 +41,10 @@ accompany the work.
 
 ### 1.3 Open Format
 
-The **work** *must* be machine-readable and provided in an open format.  An open format is
+The **work** *must* be provided in an open format. An open format is
 one which places no restrictions, monetary or otherwise, upon its use and can be fully processed
-with at least one free/libre/open-source software tool.  Data *should* be provided in bulk
-where possible.
+with at least one free/libre/open-source software tool. Data *must* be machine-readable and 
+should be provided in bulk where possibl.
 
 
 ## 2. Open Licenses

--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -44,7 +44,7 @@ accompany the work.
 The **work** *must* be provided in an open format. An open format is
 one which places no restrictions, monetary or otherwise, upon its use and can be fully processed
 with at least one free/libre/open-source software tool. Data *must* be machine-readable and 
-should be provided in bulk where possibl.
+should be provided in bulk where possible.
 
 
 ## 2. Open Licenses


### PR DESCRIPTION
We can figure out further updates later about whether we formally approve of Open Formats or otherwise flesh out the definition. For now, we *must* not require that all works be machine-readable as that detail is really a data-specific concern.