### PR TITLE
add compatibility should item

### DIFF
--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -125,18 +125,22 @@ otherwise indicate what changes have been made.
 The **license** *may* require distributions of the work to remain
 under the same license or a similar license.
 
-#### 2.2.4 Notice
+### 2.2.4 Compatibility
+
+The **license** *should* be compatible with other open licenses.
+
+#### 2.2.5 Notice
 
 The **license** *may* require retention of copyright notices and identification of the license.
 
-#### 2.2.5 Source
+#### 2.2.6 Source
 
 The **license** *may* require that anyone distributing the work provide recipients with access to the preferred form for making modifications.
 
-#### 2.2.6 Technical Restriction Prohibition
+#### 2.2.7 Technical Restriction Prohibition
 
 The **license** *may* require that distributions of the work remain free of any technical measures that would restrict the exercise of otherwise allowed rights.
 
-#### 2.2.7 Non-aggression
+#### 2.2.8 Non-aggression
 
 The **license** *may* require modifiers to grant the public additional permissions (for example, patent licenses) as required for exercise of the rights allowed by the license. The license may also condition permissions on not aggressing against licensees with respect to exercising any allowed right (again, for example, patent litigation).


### PR DESCRIPTION
Addressing #77 

I continue to think compatibility an important issue and that the definition is by far the most powerful venue this group has, so should (heh) be mentioned there.

We have other *should*s in the definition, this one is as important.

I've kept this very brief:

> The **license** *should* be compatible with other open licenses.

Some obvious ways to extend:

> The **license** *should* be compatible with other open licenses to the maximum extent possible given its policy ends.

or

> The **license** *should* be compatible with other open licenses, in particular one or more of the most commonly used copyleft licenses.

However I tend to think generality is good here, message should not prompt thinking of excuses (which ...policy ends... does) nor narrowness (which ...copyleft licesnes does).

