### PR TITLE
bulk is an access matter, form shouldn't be specific to data, machine…

### DIFF
--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -33,7 +33,7 @@ contradict the terms of the license.
 ### 1.2 Access
 
 The **work** *must* be available as a whole and at no more than a reasonable 
-one-time reproduction cost, and *should* be downloadable in bulk via the Internet without charge.
+one-time reproduction cost, and *should* be downloadable via the Internet without charge.
 Any additional information necessary for license compliance (such as names of 
 contributors required for compliance with attribution requirements) *must* also 
 accompany the work.

--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -36,13 +36,13 @@ The **work** *must* be available as a whole and at no more than a reasonable
 one-time reproduction cost, and *should* be downloadable in bulk via the Internet without charge.
 Any additional information necessary for license compliance (such as names of 
 contributors required for compliance with attribution requirements) *must* also 
-accompany the **work**.
+accompany the work.
 
 ### 1.3 Open Format
 
 The **work** *must* be provided in an open format. An open format is
 one which places no restrictions, monetary or otherwise, upon its use and can be fully processed
-with at least one free/libre/open-source software tool. The **work** *should* be provided in the form preferred for making modifications to it.
+with at least one free/libre/open-source software tool. The work *should* be provided in the form preferred for making modifications to it.
 
 ## 2. Open Licenses
 

--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -33,7 +33,7 @@ contradict the terms of the license.
 ### 1.2 Access
 
 The **work** *must* be available as a whole and at no more than a reasonable 
-one-time reproduction cost, and *should* be downloadable via the Internet without charge.
+one-time reproduction cost, and *should* be downloadable in bulk via the Internet without charge.
 Any additional information necessary for license compliance (such as names of 
 contributors required for compliance with attribution requirements) *must* also 
 accompany the **work**.
@@ -42,8 +42,7 @@ accompany the **work**.
 
 The **work** *must* be provided in an open format. An open format is
 one which places no restrictions, monetary or otherwise, upon its use and can be fully processed
-with at least one free/libre/open-source software tool. Data *must* be machine-readable and 
-*should* be provided in bulk.
+with at least one free/libre/open-source software tool. The **work** *should* be provided in the form preferred for making modifications to it.
 
 ## 2. Open Licenses
 


### PR DESCRIPTION
- move bulk should to access
- machine-readibility is implied by format must be processable by a floss tool and is otherwise vague
- data should not be called out in particular. bulk access and convenient format issues equally apply to other sorts of works, eg streaming-only access to video is bad
- preferred form for modification also covers read/parsibility, and is a should not clear to me appropriate for open definition to completely rule out eg pdfs and lossy files as Rob Myers said in https://lists.okfn.org/pipermail/od-discuss/2015-April/001339.html