### PR TITLE
License pages cleanup

### DIFF
--- a/licenses/cc-by-sa/index.markdown
+++ b/licenses/cc-by-sa/index.markdown
@@ -10,13 +10,17 @@ wordpress_id: 126
 
  * Domain of Application: Content, Data (latter 4.0 only)
 
+#### Overview
+
+http://creativecommons.org/licenses/by-sa/4.0/
+
 #### Full text 
 
- *  (v4.0)
- *  (v3.0)
- *  (v2.5)
- *  (v2.0)
- *  (v1.0; little-used/not recommended due to no upward compatibility)
+ *  [version 4.0](http://creativecommons.org/licenses/by-sa/4.0/legalcode)
+ *  [version 3.0](http://creativecommons.org/licenses/by-sa/3.0/legalcode)
+ *  [version 2.5](http://creativecommons.org/licenses/by-sa/2.5/legalcode)
+ *  [version 2.0](http://creativecommons.org/licenses/by-sa/2.0/legalcode)
+ *  [version 1.0](http://creativecommons.org/licenses/by-sa/1.0/legalcode) (little-used/not recommended due to no upward compatibility)
 
 #### Comments 
 
@@ -24,7 +28,8 @@ The Creative Commons Attribution Share-Alike license allows re-distribution and 
 
 #### How to apply 
 
-Include a link to, or a full copy of the license you use, and something like the following:
+You can use the [CC license chooser](https://creativecommons.org/choose/).
 
+Alternatively, include a link to, or a full copy of the license you use, and something like the following:
 
 > This work is licensed under a Creative Commons Attribution Share-Alike [version number] License.

--- a/licenses/cc-by/index.markdown
+++ b/licenses/cc-by/index.markdown
@@ -10,13 +10,17 @@ wordpress_id: 124
 
 * Domain of Application: Content, Data (latter 4.0 only)
 
+#### Overview
+
+https://creativecommons.org/licenses/by/4.0/
+
 #### Full text 
 
- *  (v4.0)
- *  (v3.0)
- *  (v2.5)
- *  (v2.0)
- *  (v1.0)
+ *  [version 4.0](http://creativecommons.org/licenses/by/4.0/legalcode)
+ *  [version 3.0](http://creativecommons.org/licenses/by/3.0/legalcode)
+ *  [version 2.5](http://creativecommons.org/licenses/by/2.5/legalcode)
+ *  [version 2.0](http://creativecommons.org/licenses/by/2.0/legalcode)
+ *  [version 1.0](http://creativecommons.org/licenses/by/1.0/legalcode)
 
 #### Comments 
 
@@ -24,7 +28,9 @@ The Creative Commons Attribution license allows re-distribution and re-use of a 
 
 #### How to apply 
 
-Include a link to, or a full copy of the license you use, and something like the following:
+You can use the [CC license chooser](https://creativecommons.org/choose/).
+
+Alternatively, include a link to, or a full copy of the license you use, and something like the following:
 
 > This work is licensed under a Creative Commons Attribution [version number] License.
 

--- a/licenses/cc-zero/index.markdown
+++ b/licenses/cc-zero/index.markdown
@@ -9,19 +9,22 @@ wordpress_id: 129
 ---
 
  * Domain of Application: Content, Data
-  * 
+
+#### Overview
+
+https://creativecommons.org/publicdomain/zero/1.0/
 
 #### Full text 
 
-See 
+https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 #### Comments 
 
 Intended to be a 'public domain dedication', i.e. a waiver of **all** rights including those of attribution.
 
-#### How to apply 
+#### How to apply  
 
-You can use the CC license chooser.
+You can use the [CC license chooser](https://creativecommons.org/choose/).
 
 Alternatively, include with your material:
 

--- a/licenses/odc-by/index.markdown
+++ b/licenses/odc-by/index.markdown
@@ -9,6 +9,20 @@ wordpress_id: 345
 ---
 
  * Domain of Application: Data
-  * Summary: "Attribution for Data(bases)"
-  * Home page: 
-  * Full text: 
+ 
+#### Overview
+
+http://opendatacommons.org/licenses/by/summary/
+
+#### Full text 
+
+http://opendatacommons.org/licenses/by/1.0/
+
+#### Comments 
+
+"Attribution for Data(bases)"
+
+#### How to apply  
+
+http://opendatacommons.org/licenses/by/
+

--- a/licenses/odc-odbl/index.markdown
+++ b/licenses/odc-odbl/index.markdown
@@ -9,7 +9,21 @@ wordpress_id: 147
 ---
 
  * Domain of Application: Data
-  * Summary: "Attribution Share-Alike for Databases"
-  * Full text: 
+
+#### Overview
+
+http://opendatacommons.org/licenses/odbl/summary/
+
+#### Full text 
+
+http://opendatacommons.org/licenses/odbl/1.0/
+
+#### Comments 
+
+"Attribution Share-Alike for Databases"
+
+#### How to apply  
+
+http://opendatacommons.org/licenses/odbl/
 
 

--- a/licenses/odc-pddl/index.markdown
+++ b/licenses/odc-pddl/index.markdown
@@ -10,9 +10,17 @@ wordpress_id: 149
 
  * Domain of Application: Data
 
+#### Overview
+
+http://opendatacommons.org/licenses/pddl/summary/
+
 ### Full Text 
 
 <http://opendatacommons.org/licenses/pddl/1.0/>
+
+#### Comments 
+
+“Public Domain for data/databases”
 
 ### How to Apply 
 


### PR DESCRIPTION
Looks like there was an import from Wordpress, with no real cleaning up for markdown. This work just adds some consistency and puts in more links for the 'conforming' licenses.