### PR TITLE
Link fixes on license pages

### DIFF
--- a/licenses/cc-by-sa/index.markdown
+++ b/licenses/cc-by-sa/index.markdown
@@ -12,7 +12,7 @@ wordpress_id: 126
 
 #### Overview
 
-http://creativecommons.org/licenses/by-sa/4.0/
+<http://creativecommons.org/licenses/by-sa/4.0/>
 
 #### Full text 
 

--- a/licenses/cc-by/index.markdown
+++ b/licenses/cc-by/index.markdown
@@ -12,7 +12,7 @@ wordpress_id: 124
 
 #### Overview
 
-https://creativecommons.org/licenses/by/4.0/
+<https://creativecommons.org/licenses/by/4.0/>
 
 #### Full text 
 

--- a/licenses/cc-zero/index.markdown
+++ b/licenses/cc-zero/index.markdown
@@ -12,11 +12,11 @@ wordpress_id: 129
 
 #### Overview
 
-https://creativecommons.org/publicdomain/zero/1.0/
+<https://creativecommons.org/publicdomain/zero/1.0/>
 
 #### Full text 
 
-https://creativecommons.org/publicdomain/zero/1.0/legalcode
+<https://creativecommons.org/publicdomain/zero/1.0/legalcode>
 
 #### Comments 
 

--- a/licenses/odc-by/index.markdown
+++ b/licenses/odc-by/index.markdown
@@ -12,11 +12,11 @@ wordpress_id: 345
  
 #### Overview
 
-http://opendatacommons.org/licenses/by/summary/
+<http://opendatacommons.org/licenses/by/summary/>
 
 #### Full text 
 
-http://opendatacommons.org/licenses/by/1.0/
+<http://opendatacommons.org/licenses/by/1.0/>
 
 #### Comments 
 
@@ -24,5 +24,5 @@ http://opendatacommons.org/licenses/by/1.0/
 
 #### How to apply  
 
-http://opendatacommons.org/licenses/by/
+<http://opendatacommons.org/licenses/by/>
 

--- a/licenses/odc-odbl/index.markdown
+++ b/licenses/odc-odbl/index.markdown
@@ -12,11 +12,11 @@ wordpress_id: 147
 
 #### Overview
 
-http://opendatacommons.org/licenses/odbl/summary/
+<http://opendatacommons.org/licenses/odbl/summary/>
 
 #### Full text 
 
-http://opendatacommons.org/licenses/odbl/1.0/
+<http://opendatacommons.org/licenses/odbl/1.0/>
 
 #### Comments 
 
@@ -24,6 +24,6 @@ http://opendatacommons.org/licenses/odbl/1.0/
 
 #### How to apply  
 
-http://opendatacommons.org/licenses/odbl/
+<http://opendatacommons.org/licenses/odbl/>
 
 

--- a/licenses/odc-pddl/index.markdown
+++ b/licenses/odc-pddl/index.markdown
@@ -12,7 +12,7 @@ wordpress_id: 149
 
 ### Overview
 
-http://opendatacommons.org/licenses/pddl/summary/
+<http://opendatacommons.org/licenses/pddl/summary/>
 
 ### Full Text 
 


### PR DESCRIPTION
Just checked online and the links of the markdown http:// ones that I added aren't showing up on opendefinition.org as links. See like http://opendefinition.org/licenses/odc-odbl/ The pddl one had brackets around its links, and I left them in, and they appear to continue to work. So I just changed all my links added to match that, assuming that the markdown renderer for the site needs that (github didn't, so I missed it as required formatting)