### PR TITLE
gramatical fix

### DIFF
--- a/source/open-definition-2.1-dev.markdown
+++ b/source/open-definition-2.1-dev.markdown
@@ -36,8 +36,8 @@ the work (such as a terms of use, or patents held by the licensor)
 
 ### 1.2 Access
 
-The **work** *must* be provided as a whole and at no more than a reasonable 
-one-time reproduction cost, and *should* be downloadable via the Internet without charge.
+The **work** *must* be provided as a whole at no more than a reasonable 
+one-time reproduction cost and *should* be downloadable via the Internet without charge.
 Any additional information necessary for license compliance (such as names of 
 contributors required for compliance with attribution requirements) *must* also 
 accompany the work.


### PR DESCRIPTION
the "and" and the comma in 1.2 were grammatically incorrect combinations. The second and (now the only one given my edit) was not followed by something that works as a complete sentence, and the different qualifiers make it not a consistent list that deserves comma separation. Although my result is a long sentence, I'm making this fix just to be okay for now. I would prefer to rewrite the sentence with the "should" part first and an "at least" added to the "must" part, but we've started voting on moving forward with 2.1 already.

I hope we can at least accept my grammatical fix.