### PR TITLE
Open Definition versioning: cleaner approval process, overall revisions

### DIFF
--- a/source/open-definition-revision-process-dev.markdown
+++ b/source/open-definition-revision-process-dev.markdown
@@ -2,19 +2,21 @@
 Definition Revision Approval Process _- draft_
 ====================================
 
-1. Issues with the current Open Definition are identified.  The Open Definition community will disucss on the mailing list and decide which issues are to be dealt with in the next release reach consensus on each of these issues.
+1. Issues with the current Open Definition are identified.  The Open Definition community will disucss on the mailing list or discuss.okfn.org forum and decide which issues are to be dealt with in the next release.
 
 2. A new draft document is started.  Chair notifies the list and other relevant fora that a new draft document has been started summarizing the issues that the upcoming release is to address and inviting participation.
 
-3. Issues with the current Open Definition are identified.  The Open Definition community will discuss on the mailing list and decide which issues are to be dealt with in the next release reach consensus on each of these issues.  The draft document is updated to relfect current consensus.
+3. Along with discussion, people submit pull requests to the draft until it seems to relfect current consensus.
 
-4. The Open Definition Advisory Council chair will summarize the consensus to the Advisory Council on the mailing list and to other relevant fora, okfn-discuss at a minimum.
+4. When no outstanding issues remain unsettled, the Open Definition Advisory Council chair will summarize the consensus to the Advisory Council on the mailing list and to other relevant fora, okfn-discuss at a minimum.
 
-5. If over next two weeks issues are raised which indicate a different consensus or further discussion needed, chair will step process back to step 2 or 3 as appropriate.  If no further issues are raised, the chair notifies the list and other relevant fora that the draft is ready for voting, establishing a release candidate, and informing contributors that only typo corrections will be accepted from this point forward.
+5. If, over next two weeks, issues are raised which indicate a different consensus or further discussion needed, chair will step process back to step 2 or 3 as appropriate.  If no further issues are raised, the chair holds a vote on the OD list to accept the current draft as a release candidate.
 
-6. If over next two weeks issues are raised which indicate the release candidate is not acceptable, chair will step process back to step 2.  If no further issues are raised, the chair notifies the list and other relevant fora that a vote will occur within one week.
+6. If a release candidate vote is successful, the chair will announce the release candidate to all relevant outlets including the general discussion lists and fora.
 
-7. Chair calls for formal approval of release candidate by Advisory Council on mailing list.
+7. If, over the next two weeks, issues besides typo corrections are raised that warrant being addressed before finalizing this release of the definition, the chair will step process back to step 2.  If no further issues are raised, the chair notifies the list and other relevant fora that a finalvote will occur within one week.
+
+8. Chair calls for formal approval of release candidate by Advisory Council on mailing list.
 
 8. If after two weeks at least three Advisory Council members approve the consensus summary on-list, and at least 75% of Advisory Council members expressing an opinion on the summary if any dissent, the website will be updated, and announcements made to public and wider lists as appropriate. Wider lists includes the okfn-discuss@lists.okfn.org and local@lists.okfn.org lists.  If the motion does not pass the chair notifies the list and steps the process back to step 2.
 

--- a/source/open-definition-revision-process-dev.markdown
+++ b/source/open-definition-revision-process-dev.markdown
@@ -2,21 +2,26 @@
 Definition Revision Approval Process _- draft_
 ====================================
 
-1. Issues with the current Open Definition are identified.  The Open Definition community will disucss on the mailing list or discuss.okfn.org forum and decide which issues are to be dealt with in the next release.
+1. Concerns about the current Open Definition are identified via general discussion on the mailing list or discuss.okfn.org forum.
 
-2. A new draft document is started.  Chair notifies the list and other relevant fora that a new draft document has been started summarizing the issues that the upcoming release is to address and inviting participation.
+2. The Advisory Council will then decide which concerns to dealt with for the next release.
 
-3. Along with discussion, people submit pull requests to the draft until it seems to relfect current consensus.
+3. A new draft document is started.
 
-4. When no outstanding issues remain unsettled, the Open Definition Advisory Council chair will summarize the consensus to the Advisory Council on the mailing list and to other relevant fora, okfn-discuss at a minimum.
+4. Chair notifies the list and other relevant fora that a new draft document has been started summarizing the selected concerns and inviting participation.
 
-5. If, over next two weeks, issues are raised which indicate a different consensus or further discussion needed, chair will step process back to step 2 or 3 as appropriate.  If no further issues are raised, the chair holds a vote on the OD list to accept the current draft as a release candidate.
+5. Along with discussion, people submit pull requests to the draft until it seems to reflect current consensus.
 
-6. If a release candidate vote is successful, the chair will announce the release candidate to all relevant outlets including the general discussion lists and fora.
+6. With all of the selected concerns settled, the Open Definition Advisory Council chair will summarize the consensus to the Advisory Council on the mailing list and to other relevant fora, okfn-discuss at a minimum. If only some concerns seem to be reaching consensus, the scope may be narrowed and remaining concerns delayed until a later revision.
 
-7. If, over the next two weeks, issues besides typo corrections are raised that warrant being addressed before finalizing this release of the definition, the chair will step process back to step 2.  If no further issues are raised, the chair notifies the list and other relevant fora that a finalvote will occur within one week.
+7. If, over next two weeks, concerns are raised which indicate a different consensus or further discussion needed, chair will return to prior steps as appropriate.  If no further concerns are raised, the chair holds a vote on the OD list to accept the current draft as a release candidate.
 
-8. Chair calls for formal approval of release candidate by Advisory Council on mailing list.
+8. If a release candidate vote is successful, the chair will announce the release candidate to all relevant outlets including the general discussion lists and fora.
 
-8. If after two weeks at least three Advisory Council members approve the consensus summary on-list, and at least 75% of Advisory Council members expressing an opinion on the summary if any dissent, the website will be updated, and announcements made to public and wider lists as appropriate. Wider lists includes the okfn-discuss@lists.okfn.org and local@lists.okfn.org lists.  If the motion does not pass the chair notifies the list and steps the process back to step 2.
+9. If, over the next two weeks, concerns besides typo corrections are raised that relate to the scope of this release, the chair will step process back to step 3.  If no such concerns are raised, the chair notifies the list and other relevant fora that a final vote will occur within one week.
 
+10. Chair calls for formal approval of release candidate by Advisory Council on mailing list.
+
+11. After two weeks, the release candidate becomes final given at least 3 votes of approval and at least 75% approval from all votes from Council members.  If the motion does not pass, the chair notifies the list and steps the process back as needed.
+
+12. The website will be updated, and announcements made to public and wider lists as appropriate. Wider lists includes the okfn-discuss@lists.okfn.org and local@lists.okfn.org lists.  


### PR DESCRIPTION
It makes no sense for a "release candidate" phase to have all of: a delay before a vote, and a vote, and an announcement, and a wait period, and another vote. The summary of the text from my update is:
- consensus seems apparent (no issues outstanding)
- do immediate vote on release candidate (no delay, no extra announcements)
- announce the release candidate, have delay, accept typo fixes, _readily_ move back to earlier stages to create newer release candidate if issues come up
- when through this without issues, then final vote

Basically, there's no reason to be so hesitant to get to release candidates, do them OFTEN, quickly, once known issues are done, and then don't push them through so hard.
