### PR TITLE
Experimental translation to Estonian

### DIFF
--- a/_includes/translations.md
+++ b/_includes/translations.md
@@ -5,7 +5,7 @@
 <a href="/od/2.0/cz/">Czech</a> |
 <a href="/od/1.1/da/">Dansk</a> |
 <a href="/od/2.0/de/">Deutsch</a> |
-<a href="/od/2.0/et/">Eesti</a> |
+<a href="/od/2.1/et/">Eesti</a> |
 <a href="/od/1.0/el/">Ελληνικά</a> |
 <a href="/od/{{site.od_current_version}}/en/">English</a> |
 <a href="/od/2.0/es/">Español</a> |

--- a/_includes/translations.md
+++ b/_includes/translations.md
@@ -5,6 +5,7 @@
 <a href="/od/2.0/cz/">Czech</a> |
 <a href="/od/1.1/da/">Dansk</a> |
 <a href="/od/2.0/de/">Deutsch</a> |
+<a href="/od/2.0/et/">Eesti</a> |
 <a href="/od/1.0/el/">Ελληνικά</a> |
 <a href="/od/{{site.od_current_version}}/en/">English</a> |
 <a href="/od/2.0/es/">Español</a> |

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -9,7 +9,7 @@ Avatud* definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega
 
 **Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste algupärasuse ja avatuse tagamiseks.*
 
-See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud definitsioon* töötati algselt välja avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud* definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
 
 Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
 
@@ -26,11 +26,11 @@ olla vastuolus litsentsi tingimustega.
 
 ### 1.2 Kättesaadavus
 
-**Teos** on kättesaadav tervikuna ning enimalt mõistliku, ühekordse paljundamise tasu eest, eelistatavalt tasuta allalaaditavana Internetist. Mistahes lisainfo, mis on vajalik litsentsile vastavuse tagamiseks (nagu kaastööliste nimed, mida on vaja autorsuse äramärkimise nõuetele täitmiseks) *peavad* olema samuti teosega kaasa pandud.
+**Teos** on kättesaadav tervikuna ning enimalt mõistliku, ühekordse paljundamise tasu eest, eelistatavalt tasuta allalaaditavana Internetist. Mistahes lisainfo, mis on vajalik litsentsile vastavuse tagamiseks (nagu kaastööliste nimed, mida on vaja autorsuse äramärkimise nõuete täitmiseks) *peavad* olema samuti teosega kaasa pandud.
 
 ### 1.3 Avatud vorming
 
-**Teos** *peab* olema tehtud kättesaadavaks käepärases ja täiendatavas vormis viisil, mis välistab ebavajalikud tehnoloogilised takistused litsentsitud õiguste rakendamiseks. Iseäranis andmed peavad olema masinloetavad, saadaval toormassina ning esitatud avatud vormingus (st vabalt saadaval oleva ja avaldatud spetsifikatsiooniga vormingus, mis ei sea rahalisi ega muid piiranguid selle kasutamisele) või minimaalselt on töödeldavad vähemalt ühe tarkvaralise vaba/libre/avatud lähtekoodiga tööriistaga.
+**Teos** *peab* olema tehtud kättesaadavaks käepärases ja täiendatavas vormis viisil, mis välistab tarbetud tehnoloogilised takistused litsentsitud õiguste rakendamiseks. Iseäranis andmed peavad olema masinloetavad, saadaval toormassina ning esitatud avatud vormingus (st vabalt saadaval oleva ja avaldatud spetsifikatsiooniga vormingus, mis ei sea rahalisi ega muid piiranguid selle kasutamisele) või on miinimumjuhul töödeldavad vähemalt ühe tarkvaralise vaba/libre/avatud lähtekoodiga tööriista abil.
 
 ## 2. Avatud litsentsid
 
@@ -54,11 +54,11 @@ olla vastuolus litsentsi tingimustega.
 
 #### 2.1.4 Tükeldamine
 
-**Litsents** *peab* lubama teose mistahes osa kasutamist, levitamist või täiendamist eraldiseisvalt teose mistahes muust osast või teoste kogumist, mille koosseisus seda algselt levitati. Kõik osapooled, kes saavad enda valdusse algse litsentsi raames levitatud teose või selle mistahes osa peavad omama selle suhtes neidsamu õigusi, mis olid määratletud algse teose juures.
+**Litsents** *peab* lubama teose mistahes osa kasutamist, levitamist või täiendamist eraldiseisvalt teose mistahes muust osast või teoste kogumist, mille koosseisus seda algselt levitati. Kõik osapooled, kes saavad enda valdusse algse litsentsi raames levitatud teose või selle mistahes osa, peavad omama selle suhtes neidsamu õigusi, mis olid määratletud algse teose juures.
 
 #### 2.1.5 Liitmine
 
-**Litsents** *peab* lubama litsentsitud teose levitamist koos teiste sellest eraldiseisvate teostega seadmata piiranguid neile teistele teostele.
+**Litsents** *peab* lubama litsentsitud teose levitamist koos teiste sellest eraldiseisvate teostega, seadmata piiranguid neile teistele teostele.
 
 #### 2.1.6 Ühetaolisus
 

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -5,11 +5,11 @@ layout: page
 
 Versioon 2.0
 
-Avatud* definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
+Avatud&lowast; definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
 
 **Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste algupärasuse ja avatuse tagamiseks.*
 
-See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud* definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud&lowast; definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
 
 Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
 
@@ -108,6 +108,6 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
 
-* Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus * viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
+&lowast; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud&lowast; definitsioon", kus &lowast; viitab nii käesolevale allmärkusele kui osutab ka sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
 
 _Translated by [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -107,3 +107,7 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 #### 2.2.7 Tõkestamatus
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
+
+* Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus * viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
+
+_Translated by [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -7,7 +7,7 @@ Versioon 2.0
 
 Avatud* definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
 
-**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste algupärasuse ja avatuse tagamiseks.*
+**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste allikapärasuse ja avatuse tagamiseks.*
 
 See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud* definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
 

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -110,4 +110,4 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 &#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus * viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
 
-_Translated by [Märt Põder](https://twitter.com/trtram)_
+_Tõlkinud [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -1,0 +1,109 @@
+---
+title: Avatud* definitsioon
+layout: page
+---
+
+Versioon 2.0
+
+Avatud* definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
+
+**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste algupärasuse ja avatuse tagamiseks.*
+
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud definitsioon* töötati algselt välja avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
+
+Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
+
+Termin **litsents** osutab õiguslikele tingimustele, mille alusel on teos tehtud kättesaadavaks. Juhul, kui teose litsents on määratlemata, siis tuleb seda tõlgendada kui osutust, et teose kasutust reguleerivad vaikimisi kehtivad õiguslikud tingimused (näiteks autoriõigus või avaliku hüve tingimused).
+
+## 1. Avatud teosed
+
+Avatud **teos** peab selle levitamise puhul rahuldama järgmisi nõudeid:
+
+### 1.1 Avatud litsents
+
+**Teos** *peab* olema tehtud kättesaadavaks avatud **litsentsi** alusel (defineeritud jaotises 2). Mistahes teosega kaasnevad lisatingimused (nagu kasutustingimused või litsentsija vallatavad patendid) *ei tohi* 
+olla vastuolus litsentsi tingimustega.
+
+### 1.2 Kättesaadavus
+
+**Teos** on kättesaadav tervikuna ning enimalt mõistliku, ühekordse paljundamise tasu eest, eelistatavalt tasuta allalaaditavana Internetist. Mistahes lisainfo, mis on vajalik litsentsile vastavuse tagamiseks (nagu kaastööliste nimed, mida on vaja autorsuse äramärkimise nõuetele täitmiseks) *peavad* olema samuti teosega kaasa pandud.
+
+### 1.3 Avatud vorming
+
+**Teos** *peab* olema tehtud kättesaadavaks käepärases ja täiendatavas vormis viisil, mis välistab ebavajalikud tehnoloogilised takistused litsentsitud õiguste rakendamiseks. Iseäranis andmed peavad olema masinloetavad, saadaval toormassina ning esitatud avatud vormingus (st vabalt saadaval oleva ja avaldatud spetsifikatsiooniga vormingus, mis ei sea rahalisi ega muid piiranguid selle kasutamisele) või minimaalselt on töödeldavad vähemalt ühe tarkvaralise vaba/libre/avatud lähtekoodiga tööriistaga.
+
+## 2. Avatud litsentsid
+
+**Litsents** on avatud, kui selle tingimused vastavad järgmistele nõudmistele:
+
+### 2.1 Nõutavad load
+
+**Litsents** *peab* tagasivõtmatult lubama (või võimaldama) järgmist:
+
+#### 2.1.1 Kasutus
+
+**Litsents** *peab* lubama litsentsitud teose vaba kasutamist.
+
+#### 2.1.2 Edasilevitamine
+
+**Litsents** *peab* lubama litsentsitud teose edasilevitamist, kaasa arvatud selle müüki, olenemata sellest, kas müüakse teost ennast iseseisvalt või osana kogumist, mis on loodud eri allikatest pärit teostest.
+
+#### 2.1.3 Täiendamine
+
+**Litsents** *peab* lubama tuletatud teoste loomist litsentsitud teosest ja lubama selliste tuletatud teoste levitamist samadel tingimustel algse litsentsitud teosega.
+
+#### 2.1.4 Tükeldamine
+
+**Litsents** *peab* lubama teose mistahes osa kasutamist, levitamist või täiendamist eraldiseisvalt teose mistahes muust osast või teoste kogumist, mille koosseisus seda algselt levitati. Kõik osapooled, kes saavad enda valdusse algse litsentsi raames levitatud teose või selle mistahes osa peavad omama selle suhtes neidsamu õigusi, mis olid määratletud algse teose juures.
+
+#### 2.1.5 Liitmine
+
+**Litsents** *peab* lubama litsentsitud teose levitamist koos teiste sellest eraldiseisvate teostega seadmata piiranguid neile teistele teostele.
+
+#### 2.1.6 Ühetaolisus
+
+**Litsents** *ei tohi* seada eritingimusi mitte ühelegi isikule ega isikute grupile.
+
+#### 2.1.7 Edasikanduvus
+
+Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevitatud ilma, et oleks tarvis nõustuda täiendavate õiguslike tingimustega.
+
+#### 2.1.8 Kasutamine mistahes eesmärgil
+
+**Litsents** *peab* lubama kasutamist, edasilevitamist, täiendamist ja liitmist mistahes eesmärgil. Litsents *ei tohi* mitte kellelgi piirata teose kasutamist mistahes eriliseks otstarbeks.
+
+#### 2.1.9 Tasu puudumimne
+
+**Litsents** *ei tohi* oma tingimuste osana kehtestada ühtegi honorari, kasutusmaksu ega muud rahalist tasu või hüvitist.
+
+### 2.2 Vastuvõetavad tingimused
+
+**Litsents** ei piira, muuda ebaselgeks ega vähenda muul viisil õigusi, mis on nõutud jaotises 2.1 välja arvatud järgmistel lubatud tingimustel:
+
+#### 2.2.1 Omistamine
+
+**Litsents** *võib* nõuda levitatud teose puhul, et sellega oleks pandud kaasa kaastööliste, õiguste valdajate, sponsorite või teostajate nimekiri, kuni mistahes selline ettekirjutus ei ole koormav.
+
+#### 2.2.2 Terviklus
+
+**Litsents** *võib* nõuda, et litsentsitud teose täiendus kannaks algsest teosest erinevat nime või versioonitähist või märgiks muul viisil ära, mis muudatused on teosesse tehtud.
+
+#### 2.2.3 Jagamine samal alusel
+
+**Litsents** *võib* nõuda, et litsentsitud teose koopiad või tuletatud teosed kannaksid algse teosega sama või samaväärset litsentsi.
+
+#### 2.2.4 Märkused
+
+**Litsents** *võib* nõuda autoriõiguse märkuste või litsentsimärgistuse säilitamist.
+
+#### 2.2.5 Allikad
+
+**Litsents** *võib* nõuda, et täiendatud teosed oleks tehtud kättesaadavaks vormis, mis soosib edasiste täienduste tegemist.
+
+#### 2.2.6 Tehniliste piirangute keeld
+
+**Litsents** *võib* keelata teose levitamist viisil, mis rakendab normaaljuhul lubatud õiguste teostamise takistamiseks tehnilisi meetmeid.
+
+#### 2.2.7 Tõkestamatus
+
+**Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -5,11 +5,11 @@ layout: page
 
 Versioon 2.0
 
-Avatud&lowast; definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
+Avatud* definitsioon täpsustab "avatuse" tähendust seoses teadmiste/teadmusega, kultiveerimaks lollikindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
 
 **Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ja jagada — seadmata piiranguid muuks, kui teadmiste algupärasuse ja avatuse tagamiseks.*
 
-See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud&lowast; definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](http://www.opensource.org/docs/osd) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabakultuuri teoste definitsioon](http://freedomdefined.org). Avatud* definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract).
 
 Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
 
@@ -108,6 +108,6 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
 
-&lowast; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud&lowast; definitsioon", kus &lowast; viitab nii käesolevale allmärkusele kui osutab ka sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
+&#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus * viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
 
 _Translated by [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -108,6 +108,6 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
 
-&#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus * viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
+&#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus ∗ viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
 
 _Tõlkinud [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.0/et/index.markdown
+++ b/od/2.0/et/index.markdown
@@ -108,6 +108,6 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
 
-&#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus ∗ viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
+&#42; Algne definitsioon kandis nimetust "avatud teadmuse definitsioon" (_open knowledge definition_), mille lühendamise teel on saadud praegune nimekuju (_open definition_). Kuna "avatud definitsioon" ja "avatuse definitsioon" kumbki ei anna edasi kõiki taotletud konnotatsioone, siis on valdkonnast šnitti võtva loomingulise tõlkena pakutud nimekuju "avatud* definitsioon", kus "∗" viitab nii käesolevale allmärkusele kui ka osutab sellele, et see defineerib "avatust" seoses määramata hulga valdkondadega, st esineb _wildcard_'i tähenduses.
 
 _Tõlkinud [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.1/et/index.markdown
+++ b/od/2.1/et/index.markdown
@@ -1,0 +1,125 @@
+---
+layout: page
+title: Avatud teadmuse definitsioon 2.1
+---
+
+Versioon 2.1
+
+Avatud teadmuse definitsioon täpsustab "avatuse" tähendust seoses teadmiste ja teadmusega, kultiveerimaks töökindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
+
+**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ning jagada — seadmata piiranguid muuks, kui teadmiste allikapärasuse ja avatuse tagamiseks.*
+
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](https://en.wikipedia.org/wiki/The_Open_Source_Definition) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabavara definitsioon](https://en.wikipedia.org/wiki/The_Free_Software_Definition) ja [vabakultuuri teoste definitsioon](https://en.wikipedia.org/wiki/Definition_of_Free_Cultural_Works).
+
+Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
+
+Termin **litsents** osutab õiguslikele tingimustele, mille alusel on teos tehtud kättesaadavaks.
+
+Termin **avalik omand** osutab autoriõiguse või sarnaste piirangute puudumisele, olgu siis vaikimisi või nende õiguste loovutamise tulemusena.
+
+Võtmelise tähtsusega sõnu "peab", "ei tohi", "peaks" ja "võib" tuleb käesolevas dokumendis tõlgendada nii, nagu neid kirjeldab [RFC2119](https://tools.ietf.org/html/rfc2119).
+
+## 1. Avatud teosed
+
+Avatud **teos** *peab* selle teose levitamisel rahuldama järgmisi nõudeid:
+
+### 1.1 Avatud litsents või seisund
+
+**Teos** *peab* olema **avalikus omandis** või tehtud kättesaadavaks avatud **litsentsi** alusel (defineeritud jaotises 2). Mistahes teosega kaasnevad lisatingimused (nagu kasutustingimused või litsentsija vallatavad patendid) *ei tohi* olla vastuolus teose avaliku omandi seisundi ega litsentsi tingimustega.
+
+### 1.2 Kättesaadavus
+
+**Teos** *peab* olema kättesaadav tervikuna ning enimalt mõistliku, ühekordse paljundamise tasu eest ning *võiks* olla tasuta allalaaditav Internetist. Mistahes lisainfo, mis on vajalik litsentsile vastavuse tagamiseks (nagu kaastööliste nimed, mida on vaja autorsuse äramärkimise nõuete täitmiseks) *peavad* olema samuti teosega kaasa pandud.
+
+### 1.3 Masinloetavus
+
+**Teos** *peab* olema tehtud kättesaadavaks vormis, mis võimaldab seda kergesti töödelda arvutil, kusjuures teose eraldiseisvad osad on lihtsasti ligipääsetavad ning muudetavad.
+
+### 1.4 Avatud vorming
+
+**Teos** *peab* olema tehtud kättesaadavaks avatud vormingus. Avatud vorming on selline vorming, mis ei sea kasutamisele ei rahalisi ega muid piiranguid ning on täielikult töödeldav vähemalt ühe vabal ja avatud lähtekoodil põhineva tööriistaga.
+
+## 2. Avatud litsentsid
+
+**Litsents** *võiks* ühilduda teiste avatud litsentsidega.
+
+**Litsents** on avatud, kui selle tingimused vastavad järgmistele nõudmistele:
+
+### 2.1 Nõutavad load
+
+**Litsents** *peab* tagasivõtmatult lubama (või võimaldama) järgmist:
+
+#### 2.1.1 Kasutus
+
+**Litsents** *peab* lubama litsentsitud teose vaba kasutamist.
+
+#### 2.1.2 Edasilevitamine
+
+**Litsents** *peab* lubama litsentsitud teose edasilevitamist, kaasa arvatud selle müüki, olenemata sellest, kas müüakse teost ennast iseseisvalt või osana kogumist, mis on loodud eri allikatest pärit teostest.
+
+#### 2.1.3 Täiendamine
+
+**Litsents** *peab* lubama tuletatud teoste loomist litsentsitud teosest ja lubama selliste tuletatud teoste levitamist samadel tingimustel algse litsentsitud teosega.
+
+#### 2.1.4 Tükeldamine
+
+**Litsents** *peab* lubama teose mistahes osa kasutamist, levitamist või täiendamist eraldiseisvalt teose mistahes muust osast või teoste kogumist, mille koosseisus seda algselt levitati. Kõik osapooled, kes saavad enda valdusse algse litsentsi raames levitatud teose või selle mistahes osa, *võiks* omada selle suhtes neidsamu õigusi, mis olid määratletud algse teose juures.
+
+#### 2.1.5 Liitmine
+
+**Litsents** *peab* lubama litsentsitud teose levitamist koos teiste sellest eraldiseisvate teostega, seadmata piiranguid neile teistele teostele.
+
+#### 2.1.6 Ühetaolisus
+
+**Litsents** *ei tohi* seada eritingimusi mitte ühelegi isikule ega isikute grupile.
+
+#### 2.1.7 Edasikanduvus
+
+Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevitatud ilma, et oleks tarvis nõustuda täiendavate õiguslike tingimustega.
+
+#### 2.1.8 Kasutamine mistahes eesmärgil
+
+**Litsents** *peab* lubama kasutamist, edasilevitamist, täiendamist ja liitmist mistahes eesmärgil. Litsents *ei tohi* mitte kellelgi piirata teose kasutamist mistahes eriliseks otstarbeks.
+
+#### 2.1.9 Tasu puudumimne
+
+**Litsents** *ei tohi* oma tingimuste osana kehtestada ühtegi honorari, kasutusmaksu ega muud rahalist tasu või hüvitist.
+
+### 2.2 Vastuvõetavad tingimused
+
+**Litsents** *ei tohi* piirata, muuta ebaselgeks ega vähendada muul viisil õigusi, mis on nõutud jaotises 2.1 välja arvatud järgmistel lubatud tingimustel:
+
+#### 2.2.1 Omistamine
+
+**Litsents** *võib* nõuda levitatud teose puhul, et sellega oleks pandud kaasa kaastööliste, õiguste valdajate, sponsorite või teostajate nimekiri, kuni mistahes selline ettekirjutus ei ole koormav.
+
+#### 2.2.2 Terviklus
+
+**Litsents** *võib* nõuda, et litsentsitud teose täiendus kannaks algsest teosest erinevat nime või versioonitähist või märgiks muul viisil ära, mis muudatused on teosesse tehtud.
+
+#### 2.2.3 Jagamine samal alusel
+
+**Litsents** *võib* nõuda, et levitatud teosed kannaksid teosega sama või samaväärset litsentsi.
+
+#### 2.2.4 Märkused
+
+**Litsents** *võib* nõuda autoriõiguse märkuste või litsentsimärgistuse säilitamist.
+
+#### 2.2.5 Allikad
+
+**Litsents** *võib* nõuda, et teose mistahes levitaja võimaldaks vastuvõtjatele ligipääsu teosele edasiste täienduste tegemiseks soovitatavas vormis.
+
+#### 2.2.6 Tehniliste piirangute keeld
+
+**Litsents** *võib* nõuda, et levitatud teosed ei oleks koormatud mis tahes selliste tehniliste meetmetega, mis võiksid piirata normaaljuhul lubatud õiguste teostamist.
+
+#### 2.2.7 Tõkestamatus
+
+**Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
+
+----
+*Avatud teadmuse definitsioon tuletati algselt avatud lähtekoodi definitsioonist, mis omakorda tuletati Debiani 
+
+*Avatud teadmuse definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract) ja seda raamival Debiani ühiskondlikul kokkuleppel, mille väljatöötajateks olid Bruce Perens ja Debiani arendajate kogukond. Bruce võttis hiljem sama teksti aluseks avatud lähtekoodi definitsiooni koostamisel. See definitsioon on oma põhiolemuses nende dokumentide tuletis ja kannab endas nende peamisi põhimõtteid. Vaba tarkvara ideaalide esimeseks edendajaks oli Richard Stallman ja meie jätkame seda.*
+
+_Tõlkinud [Märt Põder](https://twitter.com/trtram)_

--- a/od/2.1/et/index.markdown
+++ b/od/2.1/et/index.markdown
@@ -5,9 +5,9 @@ title: Avatud teadmuse definitsioon 2.1
 
 Versioon 2.1
 
-Avatud teadmuse definitsioon täpsustab "avatuse" tähendust seoses teadmiste ja teadmusega, kultiveerimaks töökindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
+Avatud teadmuse definitsioon täpsustab "avatuse" tähendust seoses teadmusega, kultiveerimaks töökindlat ühisvara, milles võib igaüks osaleda ning teha suurimal võimalikul määral koostööd.
 
-**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ning jagada — seadmata piiranguid muuks, kui teadmiste allikapärasuse ja avatuse tagamiseks.*
+**Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ning jagada — seadmata piiranguid muuks, kui teadmuse allikapärasuse ja avatuse tagamiseks.*
 
 See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](https://en.wikipedia.org/wiki/The_Open_Source_Definition), ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabavara definitsioon](https://en.wikipedia.org/wiki/The_Free_Software_Definition) ja [vabakultuuri teoste definitsioon](https://en.wikipedia.org/wiki/Definition_of_Free_Cultural_Works).
 

--- a/od/2.1/et/index.markdown
+++ b/od/2.1/et/index.markdown
@@ -9,7 +9,7 @@ Avatud teadmuse definitsioon täpsustab "avatuse" tähendust seoses teadmiste ja
 
 **Kokkuvõte:** *Teadmus on avatud, kui igaüks pääseb sellele vabalt ligi, saab seda vabalt kasutada, täiendada ning jagada — seadmata piiranguid muuks, kui teadmiste allikapärasuse ja avatuse tagamiseks.*
 
-See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](https://en.wikipedia.org/wiki/The_Open_Source_Definition) ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabavara definitsioon](https://en.wikipedia.org/wiki/The_Free_Software_Definition) ja [vabakultuuri teoste definitsioon](https://en.wikipedia.org/wiki/Definition_of_Free_Cultural_Works).
+See põhitähendus vastab "avatuse" tähendusele seoses tarkvaraga, nagu piiritleb seda [avatud lähtekoodi definitsioon](https://en.wikipedia.org/wiki/The_Open_Source_Definition), ning sellega on samatähenduslik "vaba" või "libre" nagu piiritleb [vabavara definitsioon](https://en.wikipedia.org/wiki/The_Free_Software_Definition) ja [vabakultuuri teoste definitsioon](https://en.wikipedia.org/wiki/Definition_of_Free_Cultural_Works).
 
 Terminit **teos** kasutatakse, osutamaks edasiantava teadmuse üksusele või selle osale.
 
@@ -17,7 +17,7 @@ Termin **litsents** osutab õiguslikele tingimustele, mille alusel on teos tehtu
 
 Termin **avalik omand** osutab autoriõiguse või sarnaste piirangute puudumisele, olgu siis vaikimisi või nende õiguste loovutamise tulemusena.
 
-Võtmelise tähtsusega sõnu "peab", "ei tohi", "peaks" ja "võib" tuleb käesolevas dokumendis tõlgendada nii, nagu neid kirjeldab [RFC2119](https://tools.ietf.org/html/rfc2119).
+Võtmelise tähtsusega sõnu "peab", "ei tohi", "võiks" ja "võib" tuleb käesolevas dokumendis tõlgendada nii, nagu neid kirjeldab [RFC2119](https://tools.ietf.org/html/rfc2119).
 
 ## 1. Avatud teosed
 
@@ -33,7 +33,7 @@ Avatud **teos** *peab* selle teose levitamisel rahuldama järgmisi nõudeid:
 
 ### 1.3 Masinloetavus
 
-**Teos** *peab* olema tehtud kättesaadavaks vormis, mis võimaldab seda kergesti töödelda arvutil, kusjuures teose eraldiseisvad osad on lihtsasti ligipääsetavad ning muudetavad.
+**Teos** *peab* olema tehtud kättesaadavaks vormis, mis võimaldab seda kergesti töödelda arvutil, kusjuures teose eraldiseisvad osad on lihtsasti ligipääsetavad ning täiendatavad.
 
 ### 1.4 Avatud vorming
 
@@ -87,7 +87,7 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 ### 2.2 Vastuvõetavad tingimused
 
-**Litsents** *ei tohi* piirata, muuta ebaselgeks ega vähendada muul viisil õigusi, mis on nõutud jaotises 2.1 välja arvatud järgmistel lubatud tingimustel:
+**Litsents** *ei tohi* piirata, muuta ebaselgeks ega vähendada muul viisil õigusi, mis on nõutud jaotises 2.1, välja arvatud järgmistel lubatavatel tingimustel:
 
 #### 2.2.1 Omistamine
 
@@ -111,15 +111,13 @@ Teosega seotud õigused *peavad* kehtima kõigi jaoks, kellele see on edasilevit
 
 #### 2.2.6 Tehniliste piirangute keeld
 
-**Litsents** *võib* nõuda, et levitatud teosed ei oleks koormatud mis tahes selliste tehniliste meetmetega, mis võiksid piirata normaaljuhul lubatud õiguste teostamist.
+**Litsents** *võib* nõuda, et levitatud teosed ei oleks koormatud ühegi tehnilise meetmega, mis võiks piirata normaaljuhul lubatud õiguste teostamist.
 
 #### 2.2.7 Tõkestamatus
 
 **Litsents** *võib* nõuda täiendajailt, et need annaksid avalikkusele täiendavaid õigusi (näiteks patendi kasutamise loa), kui seda on vaja litsentsis lubatud õiguste teostamiseks. Litsents võib ühtlasi seada õiguste tingimuseks, et litsentsisaajaid ei tõkestataks nende mistahes lubatud õiguste teostamisel (näiteks patendivaidluste algatamisega).
 
 ----
-*Avatud teadmuse definitsioon tuletati algselt avatud lähtekoodi definitsioonist, mis omakorda tuletati Debiani 
-
-*Avatud teadmuse definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract) ja seda raamival Debiani ühiskondlikul kokkuleppel, mille väljatöötajateks olid Bruce Perens ja Debiani arendajate kogukond. Bruce võttis hiljem sama teksti aluseks avatud lähtekoodi definitsiooni koostamisel. See definitsioon on oma põhiolemuses nende dokumentide tuletis ja kannab endas nende peamisi põhimõtteid. Vaba tarkvara ideaalide esimeseks edendajaks oli Richard Stallman ja meie jätkame seda.*
+*Avatud teadmuse definitsioon töötati algselt välja lähtuvalt avatud lähtekoodi definitsioonist, mis omakorda põhines [Debiani vabavara suunistel](http://www.debian.org/social_contract) ja seda raamival Debiani ühiskondlikul kokkuleppel, mille väljatöötajateks olid Bruce Perens ja Debiani arendajate kogukond. Bruce võttis hiljem sama teksti aluseks avatud lähtekoodi definitsiooni koostamisel. See definitsioon on oma põhiolemuses nende dokumentide tuletis ja kannab endas nende peamisi põhimõtteid. Vaba tarkvara ideaalide esimeseks sõnastajaks oli Richard Stallman ja meie jätkame seda tööd.*
 
 _Tõlkinud [Märt Põder](https://twitter.com/trtram)_


### PR DESCRIPTION
It is quite normal translation except for the term "open definition" itself — which is experimentally translated as "open* definition", where "∗" means wildcard for whatever is specified by the adjective "open" and also endnote referred by the same asterisk "∗" explaining that in Estonian neither "avatud definitsioon" (open[ed] definition) nor "avatuse definitsioon" (definition of openness) makes totally sense. Another option would be to translate it as "avatu definitsioon" (definition of an opened), but I believe possible options can be discussed and easily implemented with a pull request later, if we have clear idea why we choose one or another solution.