### PR TITLE
Fix wrong panel link

### DIFF
--- a/assets.okfn.org/themes/okfn/okf-panel.html
+++ b/assets.okfn.org/themes/okfn/okf-panel.html
@@ -106,7 +106,7 @@
               <ul>
                 <li><a href="http://okfn.org/about/vision/">Our Vision</a></li>
                 <li><a href="http://okfn.org/about/team/">Our Team</a></li>
-                <li><a href="http://okfn.org/jobs/">Careers</a></li>
+                <li><a href="http://okfn.org/about/jobs/">Careers</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Link to /jobs results in 404, the working link is http://okfn.org/about/jobs.

I don't know if the error is the location of the page or the link to the location, I'm assuming it's supposed to follow the same pattern as nearby links in the header panel, so I'm submitting a fix for the link.
