### PR TITLE
Tweak participation text emphasising forum over email list

### DIFF
--- a/participate/index.markdown
+++ b/participate/index.markdown
@@ -3,7 +3,7 @@ layout: page
 title: Participate
 ---
 
-The work of the Open Definition project is done in an open manner and everyone is welcome to participate. Discussions have mainly taken place on the [od-discuss mailing list](http://lists.okfn.org/mailman/listinfo/od-discuss) and new conversations are encouraged on the [Open Knowledge Forum](https://discuss.okfn.org/c/projects/OpenDefinition).
+The work of the Open Definition project is done in an open manner and everyone is welcome to participate. Conversations are encouraged on the [Open Knowledge Forum](https://discuss.okfn.org/c/projects/OpenDefinition). (Old discussions have previously taken place on the [od-discuss mailing list](http://lists.okfn.org/mailman/listinfo/od-discuss)).
 
 Also see our [issue tracker](https://github.com/okfn/opendefinition/issues) and [blog](/update/) for other opportunites.
 


### PR DESCRIPTION
Tweak participation text to make it clear that new conversations should be on the Forum rather than email list