### PR TITLE
link to non-redirect

### DIFF
--- a/licenses/eff-open-audio-license/index.markdown
+++ b/licenses/eff-open-audio-license/index.markdown
@@ -6,7 +6,9 @@ layout: page
 slug: eff-open-audio-license
 title: EFF Open Audio License
 wordpress_id: 654
-redirect_from: /eff-open-audio-licenses/
+redirect_from:
+  - /eff-open-audio-licenses/
+  - /licenses/eff-open-audio-licenses/
 ---
 
 ### EFF Open Audio License

--- a/licenses/index.markdown
+++ b/licenses/index.markdown
@@ -263,7 +263,7 @@ These licenses conform to the Open Defintion, but do not meet reusability or com
 </tr>
 
 <tr >
-<td ><a href="/licenses/eff-open-audio-licenses">EFF Open Audio License</a>
+<td ><a href="/licenses/eff-open-audio-license">EFF Open Audio License</a>
 </td>
 <td >Content
 </td>


### PR DESCRIPTION
Not sure why redirect_from producing empty destination/thus loop, in meantime, have licenses page point to preferred version not needing redirect, as it should anyway.