### PR TITLE
Update Against DRM URL to use archive.org pages

### DIFF
--- a/licenses/against-drm/index.markdown
+++ b/licenses/against-drm/index.markdown
@@ -4,7 +4,7 @@ comments: true
 date: 2009-12-20 12:19:33+00:00
 layout: page
 slug: against-drm
-title: 'Against DRM '
+title: 'Against DRM'
 wordpress_id: 119
 ---
 
@@ -12,7 +12,11 @@ wordpress_id: 119
 
 #### Full text 
 
-<http://www.freecreations.org/Against_DRM2.html> also available in [translations](http://www.freecreations.org/translations.html).
+http://web.archive.org/web/20060612204158/http://www.freecreations.org/Against_DRM2.html
+
+Spanish, French, and Italian translations are available:
+
+https://web.archive.org/web/20070206053316/http://www.freecreations.org/translations.html
 
 #### Comments 
 


### PR DESCRIPTION
The original website (freecreations.org) has an expired DNS record, and seems like it won't be coming back.

See issue #160.