### PR TITLE
Update EFF OAL URLs to use archive.org pages

### DIFF
--- a/licenses/eff-open-audio-license/index.markdown
+++ b/licenses/eff-open-audio-license/index.markdown
@@ -15,9 +15,9 @@ redirect_from:
 
 #### Full text
 
-http://www.eff.org/IP/Open_licenses/eff_oal_version1.php
+https://web.archive.org/web/20040818074301/http://www.eff.org/IP/Open_licenses/20010421_eff_oal_1.0.html
 
 #### Comments
 
-As of v2.0 merged with CC by-sa license: 'EFF designates the Creative Commons Attribution Share-Alike license as version 2.0 of the Open Audio License.' [source on eff site](http://www.eff.org/IP/Open_licenses/eff_oal.php)
+As of v2.0 merged with CC by-sa license: 'EFF designates the Creative Commons Attribution Share-Alike license as version 2.0 of the Open Audio License.' [source on archive of EFF website](https://web.archive.org/web/20040602195332/http://www.eff.org/IP/Open_licenses/eff_oal.html)
 


### PR DESCRIPTION
The original pages don't seem to be on the EFF website any more.

See issue #160.