### PR TITLE
show translation links in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,17 @@
 <footer class="site-footer">
   <div class="wrapper">
 
+    <div class="footer-language-links">
+      <p>
+      The Open Definition in Your Language
+        <ul>
+        {% include translations.html %}
+        </ul>
+      </p>
+    </div>
+
+    <hr>
+
     <div class="footer-primary-links">
       <a class="footer-logo" href="https://okfn.org/">
         <img src="https://a.okfn.org/img/oki/landscape-white-234x61.png">

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -44,7 +44,7 @@ html {
       @media (min-width: $large-screen) {
         float: left;
         margin-left: 1em;
-        margin-bottom: 0;
+        margin-bottom: 1em;
       }
     }
 
@@ -120,6 +120,17 @@ html {
             opacity: 1;
           }
         }
+      }
+    }
+
+    .footer-language-links {
+      ul {
+        padding-left: 0;
+      }
+      li {
+        font-size: .8em;
+        font-weight: 400;
+        display: inline;
       }
     }
   }


### PR DESCRIPTION
from #201

> I wish OD translations weren't relatively hidden

Its useful to have them in the menu, but I think you're right that we can make it clearer that the translations are available. I'm sure there is a group of users who don't know enough English to find "The Open Definition in Your Language" but will spot "日本語", for example .
How about we also double-up the language links in the footer, like this?