### PR TITLE
Move licenses API docs to opendefinition.org

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -7,7 +7,12 @@
       <a href="/od/{{site.od_current_version}}/en/">The Definition</a>
     </li>
     <li>
-      <a href="/licenses/">Conformant Licenses</a>
+      <a>Licenses</a>
+      <ul>
+        <li><a href="/licenses/">Conformant Licenses</a></li>
+        <li><a href="/licenses/process">Approval Process</a></li>
+        <li><a href="/licenses/api">Licenses API</a></li>
+      </ul>
     </li>
     <li>
       <a href="/participate/">Participate</a>

--- a/_sass/_api.scss
+++ b/_sass/_api.scss
@@ -1,0 +1,18 @@
+.license-list {
+  margin-top: 1rem;
+  clear: both;
+}
+
+.license .icons .open-icon {
+  padding-right: 3px;
+}
+
+.license {
+  min-height:20px;
+  padding:19px;
+  margin-bottom:20px;
+  border:1px solid #e3e3e3;
+  -webkit-border-radius:4px;
+  -moz-border-radius:4px;
+  border-radius:4px;
+}

--- a/assets.okfn.org/js/api-docs.js
+++ b/assets.okfn.org/js/api-docs.js
@@ -1,0 +1,61 @@
+jQuery(document).ready(function($) {
+  var template = $($('.template-license').html());
+  var $list = $('.license-list');
+  var $isOpenData = $('<a href="https://opendefinition.org/od/" title="Open Data" class="open-icon"><img src="https://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="Open Data" /></a>');
+  var $isOpenContent = $('<a href="https://opendefinition.org/od/" title="Open Data" class="open-icon"><img src="https://assets.okfn.org/images/ok_buttons/oc_80x15_red_green.png" alt="Open Data" /></a>');
+  $.each(all_licenses, function(id, data) {
+    var tmp = template.clone();
+    var jsonUrl = 'https://licenses.opendefinition.org/licenses/' + id + '.json';
+    $.each(data, function(key, value) {
+      tmp.find('.tmpl-' + key).html(value);
+    });
+    tmp.attr('data-license-id', data.id);
+    tmp.find('.tmpl-title').attr('href', jsonUrl);
+    tmp.find('.tmpl-url').attr('href', data.url);
+    if (data.od_conformance === "approved" && data.domain_data) {
+      tmp.find('.icons').append($isOpenData.clone());
+    }
+    if (data.od_conformance === "approved" && data.domain_content) {
+      tmp.find('.icons').append($isOpenContent.clone());
+    }
+    $list.append(tmp);
+  });
+
+  $('.license-filter').change(onFormChange);
+  $('.license-filter').submit(onFormChange);
+  $('.license-filter .search-query').keyup(onFormChange);
+  $('.license-filter').trigger('submit');
+
+  function onFormChange(e) {
+    e.preventDefault();
+    var $form = $(e.target).closest('form');
+    var data = {
+      q: '',
+      od_conformance: null,
+      osd_conformance: null
+    };
+    $($form.serializeArray()).each(function(idx, item) {
+      data[item.name] = item.value;
+    });
+    $('.license-list .license').each(function(idx, $el) {
+      $el = $($el);
+      var matched = false;
+      var _id = $el.attr('data-license-id');
+      var _lic = all_licenses[_id];
+      if (_lic.title.toLowerCase().match(RegExp(data.q))) {
+        matched = true;
+      }
+      if (data.osd_conformance === "approved") {
+        matched = matched && _lic.osd_conformance === "approved";
+      }
+      if (data.od_conformance === "approved") {
+        matched = matched && _lic.od_conformance === "approved";
+      }
+      if (matched) {
+        $el.show();
+      } else {
+        $el.hide();
+      }
+    });
+  }
+});

--- a/css/main.scss
+++ b/css/main.scss
@@ -12,4 +12,5 @@
   'syntax',
   'footer',
   'body',
-  'ok-ribbon';
+  'ok-ribbon',
+  'api';

--- a/licenses/api/index.markdown
+++ b/licenses/api/index.markdown
@@ -1,0 +1,117 @@
+---
+layout: page
+slug: licenses-api
+title: Licenses API
+---
+
+<blockquote>
+  <h2>The <a href="https://opendefinition.org">Open Definition</a> states: &quot;A piece of content or data is open if anyone is free to use, reuse, and redistribute it — subject only, at most, to the requirement to attribute and share-alike.&quot;</h2>
+</blockquote>
+
+<h2>Data on more than 100 open licenses</h2>
+<p>Including all <a href="https://opensource.org/licenses">OSI-approved open source
+    licenses</a> and all <a href="https://opendefinition.org/licenses">Open
+    Definition conformant open data and content licenses</a>. Provided in easy to use, <a href="#format">machine readable JSON</a> -- perfect if you need to drop a license chooser into your app.</p>
+<p><a href="#all-licenses" class="btn primary">View the licenses available</a></p>
+<h3>License Groups</h3>
+<p>In addition various generic groups are provided that are useful when constructing license choice lists, including non-commercial options, generic Public Domain and more. Pre-packaged groups include:</p>
+<ul>
+    <li><a href="https://licenses.opendefinition.org/licenses/groups/all.json">All licenses</a></li>
+    <li><a href="https://licenses.opendefinition.org/licenses/groups/osi.json">OSI compliant</a></li>
+    <li><a href="https://licenses.opendefinition.org/licenses/groups/od.json">Open Definition compliant</a></li>
+    <li><a href="https://licenses.opendefinition.org/licenses/groups/ckan.json">Specially selected set</a> developed for <a href="https://ckan.org/">CKAN</a> that is perfect for data and content site license choosers.</li>
+</ul>
+
+<h2 id="format">Format</h2>
+<p>JSON hashes with the following keys:</p>
+<pre>{
+    "id": "ODC-BY-1.0", 
+    "domain_content": false, 
+    "domain_data": true, 
+    "domain_software": false, 
+    "od_conformance": "approved", 
+    "osd_conformance": "not reviewed", 
+    "status": "active", 
+    "title": "Open Data Commons Attribution License 1.0", 
+    "url": "https://opendatacommons.org/licenses/by"
+}</pre>
+<p>Spot an error, think we should have more info? Please file an <a href="https://github.com/okfn/licenses/issues">issue</a> or submit a patch.</p>
+
+<hr />
+
+<h2 id="how-to">How do I use it?</h2>
+
+<h3>Get the data</h3>
+<p>Download the licenses, either <a href="https://licenses.opendefinition.org/licenses/groups/all.json">all in one</a>, individually (see below) or in specific groups (see above).</p>
+<p>For example, here's how to use curl to access an individual license:</p>
+<p><pre>curl https://licenses.opendefinition.org/licenses/ODC-BY-1.0.json</pre></p>
+
+<p>And here's how to use curl to access the CKAN license group:</p>
+<p><pre>curl https://licenses.opendefinition.org/licenses/groups/ckan.json</pre></p>
+
+<h3>Git Access</h3>
+<p>You can also get the material as a git repo:</p>
+<p><pre>git clone https://github.com/okfn/licenses</pre></p>
+
+
+<h3>Javascript Access (JSONP)</h3>
+<p>We also provide a simple way to get direct access from javascript in the browser using JSONP, by providing versions of the all of the data in the jsonp subdirectory wrapped in a callback function named <pre>license_callback</pre></p>
+<p>Thus, the JSONP version of a file named:
+<p><pre>xyz.json</pre></p>
+<p>whether it is a license group or an individual license, will be located at:</p>
+<p><pre>licenses/jsonp/xyz.json</pre></p>
+
+<p>For example from jQuery:</p>
+<pre>$.ajax({
+    url:'https://licenses.opendefinition.org/groups/jsonp/ODC-BY-1.0.js',
+    dataType: 'jsonp',
+    // you *must* set the callback function to be license_callback
+    jsonpCallback: 'license_callback',
+    success: function(data) {
+        console.log('License title is ' + data.title);
+    }
+});</pre>
+
+<p>Because our JSONP data is served from a static files, it has a hardcoded callback function and therefore <strong>must</strong> name your callback function for the JSONP request <pre>license_callback</pre></p>
+
+<hr />
+
+<h2 id="all-licenses">Licenses List</h2>
+<form class="form-horizontal form-search license-filter">
+  <p><input type="text" name="q" placeholder="Filter" class="search-query span5" /></p>
+
+  <label class="checkbox">
+  <input type="checkbox" name="od_conformance" value="approved" checked="" />
+    Approved as conforming to the Open Definition
+  </label>
+  <br />
+  <label class="checkbox">
+  <input type="checkbox" name="osd_conformance" value="approved" />
+    Approved as conforming to the Open Source Definition
+  </label>
+</form>
+
+<div class="license-list"></div>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
+<script type="text/javascript">
+  // GLOBAL
+  var all_licenses = null;
+  // Setup callback for jsonp to use
+  function license_callback(data) {
+    all_licenses = data;
+  }
+</script>
+<script src="https://licenses.opendefinition.org/licenses/jsonp/all.js"></script>
+<script src="/assets.okfn.org/js/api-docs.js" type="text/javascript"></script>
+<script type="x-template" class="template-license">
+  <div class="license" data-license-id="">
+    <div class="">
+      <h3>
+        <a href="" class="tmpl-title"></a>
+        <div class="icons"></div>
+      </h3>
+      <p><a href="" class="tmpl-url"></a></p>
+      <p>Status: <span class="tmpl-status"></span></p>
+    </div>
+  </div>
+</script>


### PR DESCRIPTION
One of the objectives of this visual refresh is to bring the look-and-feel of https://licenses.opendefinition.org/ into line with the current OKFN branding. 

There are two long-standing issues at

* https://github.com/okfn/licenses/issues/45
* https://github.com/okfn/opendefinition/issues/7

where moving the API documentation out of the seperate site/repo and into the main Open Definition site/repo is discussed. These issues broadly seemed to gain some approval from the community but were never really actively worked on. Now seems like a good time to revive this plan though as by far the easiest approach to updating the styling there is to move that one page of content into this repo.

As such, I've grabbed the documentation from https://github.com/okfn/licenses/blob/master/index.html and moved it over to this site (updating where appropriate) and left all the JSON/data where it is. I've also submitted a companion PR over at https://github.com/okfn/licenses/pull/93 replacing the index page on licenses.opendefinition.org with a client-side redirect to https://opendefinition.org/licenses/api/ (which doesn't exist yet, but will once this is merged).

This doesn't fully close either of the referenced issues as there was also some additional discussion there around changes to the API/data. I have not addressed these here.