### PR TITLE
use page title as article header

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,5 +1,6 @@
 ---
 layout: default
 ---
+<h2>{{page.title}}</h2>
 
 {{content}}


### PR DESCRIPTION
As noted by @StephenAbbott we lost the page titles somewhere in the redesign.

**Before:**
![Screenshot_2020-09-11 Open Data Commons Attribution License - Open Definition - Defining Open in Open Data, Open Content an (1)](https://user-images.githubusercontent.com/6025893/92904383-bb7bc800-f41a-11ea-8e5d-bd39b9d9d4bb.png)


**After:**
![Screenshot_2020-09-11 Open Data Commons Attribution License - Open Definition - Defining Open in Open Data, Open Content an](https://user-images.githubusercontent.com/6025893/92904400-be76b880-f41a-11ea-8ac3-7c63b5d96f2e.png)
